### PR TITLE
fix: correct API pricing and current-cycle summaries

### DIFF
--- a/Sources/CodexRunway/ApiCostDetailView.swift
+++ b/Sources/CodexRunway/ApiCostDetailView.swift
@@ -169,8 +169,12 @@ struct ApiCostDetailView: View {
     private func header(_ detail: ApiEquivalentSummary) -> some View {
         RunwayPageSummaryRow(
             title: l10n.text(.apiCost),
-            meta: "\(l10n.text(.calculatedAt)) \(calculatedText(detail.calculatedAt)) · \(detail.pricingVersion) · \(sourceText(detail.source))",
+            meta: "\(windowText(detail.window)) · \(l10n.text(.calculatedAt)) \(calculatedText(detail.calculatedAt)) · \(detail.pricingVersion) · \(sourceText(detail.source))",
             figure: detail.estimatedUSD.map(DurationFormatter.money) ?? l10n.text(.tokensOnly))
+    }
+
+    private func windowText(_ window: DateInterval) -> String {
+        "\(calculatedText(window.start)) – \(calculatedText(window.end))"
     }
 
     @ViewBuilder

--- a/Sources/CodexRunway/RunwayModel.swift
+++ b/Sources/CodexRunway/RunwayModel.swift
@@ -1674,8 +1674,7 @@ final class RunwayModel: ObservableObject {
             let range = try await resolveGrokCurrentCycleCostRange()
             if let grokCostDetail,
                grokCostDetail.isDisplayableCost,
-               abs(grokCostDetail.window.start.timeIntervalSince(range.window.start)) < 60,
-               grokCostDetail.window.end <= range.window.end.addingTimeInterval(120)
+               Self.costWindow(grokCostDetail.window, matches: range.window)
             {
                 return grokCostDetail
             }
@@ -1686,12 +1685,19 @@ final class RunwayModel: ObservableObject {
         // Reuse an in-memory current-cycle snapshot only when its window still matches.
         if let costDetail,
            costDetail.isDisplayableCost,
-           abs(costDetail.window.start.timeIntervalSince(range.window.start)) < 60,
-           costDetail.window.end <= range.window.end.addingTimeInterval(120)
+           Self.costWindow(costDetail.window, matches: range.window)
         {
             return costDetail
         }
         return try await queryCost(range: range)
+    }
+
+    private static func costWindow(
+        _ snapshot: DateInterval,
+        matches requested: DateInterval
+    ) -> Bool {
+        abs(snapshot.start.timeIntervalSince(requested.start)) < 60
+            && abs(snapshot.end.timeIntervalSince(requested.end)) < 120
     }
 
     func previousCycleCostRange() -> ApiCostRange? {
@@ -2285,6 +2291,10 @@ final class RunwayModel: ObservableObject {
     }
 
     private func applyCurrentCost(_ summary: ApiEquivalentSummary) {
+        if let latestCost, latestCost.pricingVersion != summary.pricingVersion {
+            detailCostCache = [:]
+            detailCostCacheOrder = []
+        }
         latestCost = summary
         costDetail = summary
         cacheCost(summary)

--- a/Sources/CodexRunwayCore/CostScanner.swift
+++ b/Sources/CodexRunwayCore/CostScanner.swift
@@ -76,7 +76,7 @@ public struct UsageCostScanner: Sendable {
         calculatedAt: Date = Date()) throws -> UsageCostScanReport<ApiEquivalentSummary>
     {
         var byModel: [String: ApiEquivalentTotals] = [:]
-        var byProject: [String: ApiEquivalentTotals] = [:]
+        var byProjectModel: [String: [String: ApiEquivalentTotals]] = [:]
         var byDay: [String: ApiEquivalentTotals] = [:]
         var byDayModel: [String: [String: ApiEquivalentTotals]] = [:]
         var unknown = Set<String>()
@@ -88,7 +88,7 @@ public struct UsageCostScanner: Sendable {
                 file: file,
                 window: window,
                 byModel: &byModel,
-                byProject: &byProject,
+                byProjectModel: &byProjectModel,
                 byDay: &byDay,
                 byDayModel: &byDayModel,
                 unknown: &unknown,
@@ -97,20 +97,23 @@ public struct UsageCostScanner: Sendable {
         }
         let modelRows = byModel.keys.sorted().map { model in
             let totals = byModel[model] ?? .zero
-            let estimated = PricingTable.cost(model: model, totals: totals) ?? PricingTable.equivalentCost(totals: totals)
+            let estimated = PricingTable.cost(model: model, totals: totals)
             return ApiEquivalentBreakdownRow(name: model, totals: totals, estimatedUSD: estimated, rawCredits: 0)
         }
-        let projectRows = byProject.keys.sorted { lhs, rhs in
-            let left = byProject[lhs]?.totalTokens ?? 0
-            let right = byProject[rhs]?.totalTokens ?? 0
-            return left == right ? lhs < rhs : left > right
-        }.map { project in
-            let totals = byProject[project] ?? .zero
-            return ApiEquivalentBreakdownRow(
+        var projectRows: [ApiEquivalentBreakdownRow] = []
+        projectRows.reserveCapacity(byProjectModel.count)
+        for (project, projectModels) in byProjectModel {
+            let projectTotals = try ApiEquivalentTotals.sum(projectModels.values)
+            projectRows.append(ApiEquivalentBreakdownRow(
                 name: project,
-                totals: totals,
-                estimatedUSD: PricingTable.equivalentCost(totals: totals),
-                rawCredits: 0)
+                totals: projectTotals,
+                estimatedUSD: Self.estimatedCost(byModel: projectModels),
+                rawCredits: 0))
+        }
+        projectRows.sort { lhs, rhs in
+            lhs.totals.totalTokens == rhs.totals.totalTokens
+                ? lhs.name < rhs.name
+                : lhs.totals.totalTokens > rhs.totals.totalTokens
         }
         let dailyRows = byDay.keys.sorted().map { day in
             let totals = byDay[day] ?? .zero
@@ -121,6 +124,15 @@ public struct UsageCostScanner: Sendable {
                 rawCredits: 0)
         }
         let totals = try ApiEquivalentTotals.sum(byDay.values)
+        let estimatedUSD = Self.estimatedCost(byModel: byModel)
+        let confidence: ApiEquivalentConfidence
+        if totals.totalTokens == 0 {
+            confidence = .unavailable
+        } else if estimatedUSD == nil {
+            confidence = .tokensOnly
+        } else {
+            confidence = .priced
+        }
         var warnings = unknown.sorted().map { "unknown-model:\($0)" }
         if diagnostics.oversizedLines > 0 {
             warnings.append("oversized-jsonl-lines:\(diagnostics.oversizedLines)")
@@ -128,9 +140,9 @@ public struct UsageCostScanner: Sendable {
         return UsageCostScanReport(
             summary: ApiEquivalentSummary(
                 source: totals.totalTokens > 0 ? .localSessions : .unavailable,
-                confidence: totals.totalTokens > 0 ? .priced : .unavailable,
+                confidence: confidence,
                 window: window,
-                estimatedUSD: modelRows.compactMap(\.estimatedUSD).reduce(Decimal(0), +),
+                estimatedUSD: estimatedUSD,
                 totals: totals,
                 dailyRows: dailyRows,
                 modelRows: modelRows,
@@ -170,7 +182,7 @@ public struct UsageCostScanner: Sendable {
         file: URL,
         window: DateInterval,
         byModel: inout [String: ApiEquivalentTotals],
-        byProject: inout [String: ApiEquivalentTotals],
+        byProjectModel: inout [String: [String: ApiEquivalentTotals]],
         byDay: inout [String: ApiEquivalentTotals],
         byDayModel: inout [String: [String: ApiEquivalentTotals]],
         unknown: inout Set<String>,
@@ -193,8 +205,10 @@ public struct UsageCostScanner: Sendable {
             let totals = try ApiEquivalentTotals(validating: usage, turns: 1, threads: 0)
             let day = record.dayKey
             byModel[model, default: .zero] = try byModel[model, default: .zero].adding(totals)
-            byProject[currentProject, default: .zero] = try byProject[currentProject, default: .zero]
-                .adding(totals)
+            byProjectModel[currentProject, default: [:]][model, default: .zero] = try byProjectModel[
+                currentProject,
+                default: [:]
+            ][model, default: .zero].adding(totals)
             byDay[day, default: .zero] = try byDay[day, default: .zero].adding(totals)
             byDayModel[day, default: [:]][model, default: .zero] = try byDayModel[
                 day,
@@ -257,10 +271,15 @@ public struct UsageCostScanner: Sendable {
         return RunwayDates.parse(String(name[match]) + "T00:00:00Z")
     }
 
-    private static func estimatedCost(byModel: [String: ApiEquivalentTotals]) -> Decimal {
-        byModel.reduce(Decimal(0)) { result, item in
-            result + (PricingTable.cost(model: item.key, totals: item.value) ?? PricingTable.equivalentCost(totals: item.value))
+    private static func estimatedCost(byModel: [String: ApiEquivalentTotals]) -> Decimal? {
+        var result = Decimal(0)
+        for item in byModel {
+            guard let cost = PricingTable.cost(model: item.key, totals: item.value) else {
+                return nil
+            }
+            result += cost
         }
+        return result
     }
 }
 
@@ -286,26 +305,111 @@ extension ApiEquivalentTotals {
 }
 
 public enum PricingTable {
-    public static let version = "2026-06-29"
+    /// Bundled fallback verified against the official OpenAI pricing documentation.
+    public static let version = "openai-builtin-2026-08-13"
 
-    public struct Price: Sendable {
+    public struct Price: Codable, Equatable, Sendable {
         var inputPerMillion: Decimal
         var cachedInputPerMillion: Decimal
+        var cacheWritePerMillion: Decimal?
         var outputPerMillion: Decimal
+        var longContextInputPerMillion: Decimal?
+        var longContextCachedInputPerMillion: Decimal?
+        var longContextCacheWritePerMillion: Decimal?
+        var longContextOutputPerMillion: Decimal?
+
+        init(
+            inputPerMillion: Decimal,
+            cachedInputPerMillion: Decimal,
+            cacheWritePerMillion: Decimal? = nil,
+            outputPerMillion: Decimal,
+            longContextInputPerMillion: Decimal? = nil,
+            longContextCachedInputPerMillion: Decimal? = nil,
+            longContextCacheWritePerMillion: Decimal? = nil,
+            longContextOutputPerMillion: Decimal? = nil)
+        {
+            self.inputPerMillion = inputPerMillion
+            self.cachedInputPerMillion = cachedInputPerMillion
+            self.cacheWritePerMillion = cacheWritePerMillion
+            self.outputPerMillion = outputPerMillion
+            self.longContextInputPerMillion = longContextInputPerMillion
+            self.longContextCachedInputPerMillion = longContextCachedInputPerMillion
+            self.longContextCacheWritePerMillion = longContextCacheWritePerMillion
+            self.longContextOutputPerMillion = longContextOutputPerMillion
+        }
     }
 
+    static let builtInPrices: [String: Price] = [
+        "gpt-5.6": Price(
+            inputPerMillion: 5,
+            cachedInputPerMillion: 0.5,
+            cacheWritePerMillion: 6.25,
+            outputPerMillion: 30,
+            longContextInputPerMillion: 10,
+            longContextCachedInputPerMillion: 1,
+            longContextCacheWritePerMillion: 12.5,
+            longContextOutputPerMillion: 45),
+        "gpt-5.6-sol": Price(
+            inputPerMillion: 5,
+            cachedInputPerMillion: 0.5,
+            cacheWritePerMillion: 6.25,
+            outputPerMillion: 30,
+            longContextInputPerMillion: 10,
+            longContextCachedInputPerMillion: 1,
+            longContextCacheWritePerMillion: 12.5,
+            longContextOutputPerMillion: 45),
+        "gpt-5.6-terra": Price(
+            inputPerMillion: 2,
+            cachedInputPerMillion: 0.2,
+            cacheWritePerMillion: 2.5,
+            outputPerMillion: 12,
+            longContextInputPerMillion: 4,
+            longContextCachedInputPerMillion: 0.4,
+            longContextCacheWritePerMillion: 5,
+            longContextOutputPerMillion: 18),
+        "gpt-5.6-luna": Price(
+            inputPerMillion: 0.2,
+            cachedInputPerMillion: 0.02,
+            cacheWritePerMillion: 0.25,
+            outputPerMillion: 1.2,
+            longContextInputPerMillion: 0.4,
+            longContextCachedInputPerMillion: 0.04,
+            longContextCacheWritePerMillion: 0.5,
+            longContextOutputPerMillion: 1.8),
+        "gpt-5.5": Price(inputPerMillion: 5, cachedInputPerMillion: 0.5, outputPerMillion: 30),
+        "gpt-5.5-pro": Price(inputPerMillion: 30, cachedInputPerMillion: 30, outputPerMillion: 180),
+        "gpt-5.4": Price(inputPerMillion: 2.5, cachedInputPerMillion: 0.25, outputPerMillion: 15),
+        "gpt-5.4-pro": Price(inputPerMillion: 30, cachedInputPerMillion: 30, outputPerMillion: 180),
+        "gpt-5.4-mini": Price(inputPerMillion: 0.75, cachedInputPerMillion: 0.075, outputPerMillion: 4.5),
+        "gpt-5.4-nano": Price(inputPerMillion: 0.2, cachedInputPerMillion: 0.02, outputPerMillion: 1.25),
+        "gpt-5.3-codex": Price(inputPerMillion: 1.75, cachedInputPerMillion: 0.175, outputPerMillion: 14),
+        "gpt-5.2-codex": Price(inputPerMillion: 1.75, cachedInputPerMillion: 0.175, outputPerMillion: 14),
+        "gpt-5.2": Price(inputPerMillion: 1.75, cachedInputPerMillion: 0.175, outputPerMillion: 14),
+        "gpt-5.1": Price(inputPerMillion: 1.25, cachedInputPerMillion: 0.125, outputPerMillion: 10),
+        "gpt-5": Price(inputPerMillion: 1.25, cachedInputPerMillion: 0.125, outputPerMillion: 10),
+        "gpt-5-mini": Price(inputPerMillion: 0.25, cachedInputPerMillion: 0.025, outputPerMillion: 2),
+        "gpt-5-nano": Price(inputPerMillion: 0.05, cachedInputPerMillion: 0.005, outputPerMillion: 0.4),
+        "gpt-5-pro": Price(inputPerMillion: 15, cachedInputPerMillion: 15, outputPerMillion: 120),
+        "codex-mini-latest": Price(inputPerMillion: 1.5, cachedInputPerMillion: 0.375, outputPerMillion: 6),
+    ]
+
     public static func price(for model: String) -> Price? {
-        let key = model.lowercased()
-        if key.contains("gpt-5.3-codex") || key.contains("gpt-5.2-codex") {
-            return Price(inputPerMillion: 1.75, cachedInputPerMillion: 0.175, outputPerMillion: 14)
-        }
-        if key.contains("gpt-5.5") {
-            return equivalentPrice
-        }
-        if key.contains("gpt-5") {
-            return Price(inputPerMillion: 1.25, cachedInputPerMillion: 0.125, outputPerMillion: 10)
-        }
-        return nil
+        price(for: model, in: builtInPrices)
+    }
+
+    static func price(for model: String, in prices: [String: Price]) -> Price? {
+        let key = normalizedModelID(model)
+        if let exact = prices[key] { return exact }
+        guard let snapshotBase = snapshotBaseModelID(key) else { return nil }
+        return prices[snapshotBase]
+    }
+
+    static func mergedPrices(overrides: [String: Price]) -> [String: Price] {
+        builtInPrices.merging(overrides) { _, remote in remote }
+    }
+
+    static func isCompatibleCacheVersion(_ value: String) -> Bool {
+        value == version || value.hasPrefix("openai-docs-")
     }
 
     public static func cost(model: String, usage: TokenUsage) -> Decimal? {
@@ -323,7 +427,19 @@ public enum PricingTable {
     }
 
     static var equivalentPrice: Price {
-        Price(inputPerMillion: 5, cachedInputPerMillion: 0.5, outputPerMillion: 30)
+        builtInPrices["gpt-5.6-sol"]!
+    }
+
+    private static func normalizedModelID(_ model: String) -> String {
+        model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func snapshotBaseModelID(_ model: String) -> String? {
+        let suffixPattern = #"-\d{4}-\d{2}-\d{2}$"#
+        guard let range = model.range(of: suffixPattern, options: .regularExpression) else {
+            return nil
+        }
+        return String(model[..<range.lowerBound])
     }
 
     private static func cost(usage: TokenUsage, price: Price) -> Decimal {

--- a/Sources/CodexRunwayCore/OpenAIPricingCatalog.swift
+++ b/Sources/CodexRunwayCore/OpenAIPricingCatalog.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+enum OpenAIPricingCatalogError: Error, Equatable {
+    case invalidResponse
+    case invalidStatus(Int)
+    case invalidMarkdown
+    case emptyCatalog
+}
+
+struct OpenAIPricingHTTPResponse: Sendable {
+    var statusCode: Int
+    var data: Data
+    var eTag: String?
+    var lastModified: String?
+}
+
+typealias OpenAIPricingFetcher = @Sendable (_ eTag: String?) async throws -> OpenAIPricingHTTPResponse
+
+enum OpenAIPricingMarkdownParser {
+    private static let standardHeading = "### Standard pricing data"
+
+    static func parseStandardPrices(_ markdown: String) throws -> [String: PricingTable.Price] {
+        var insideStandardTable = false
+        var sawHeader = false
+        var result: [String: PricingTable.Price] = [:]
+
+        for rawLine in markdown.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line == standardHeading {
+                insideStandardTable = true
+                continue
+            }
+            guard insideStandardTable else { continue }
+            if line.hasPrefix("### ") { break }
+            guard line.hasPrefix("|") else { continue }
+
+            let cells = tableCells(line)
+            guard cells.count == 9 else { continue }
+            if cells[0] == "Model" {
+                sawHeader = true
+                continue
+            }
+            if cells[0].allSatisfy({ $0 == "-" || $0 == ":" }) { continue }
+            guard sawHeader else { continue }
+
+            let model = normalizedModelID(cells[0])
+            guard isCodexCompatibleModelID(model),
+                  let input = decimal(cells[1]),
+                  let output = decimal(cells[4])
+            else { continue }
+            let cached = decimal(cells[2]) ?? input
+            let price = PricingTable.Price(
+                inputPerMillion: input,
+                cachedInputPerMillion: cached,
+                cacheWritePerMillion: decimal(cells[3]),
+                outputPerMillion: output,
+                longContextInputPerMillion: decimal(cells[5]),
+                longContextCachedInputPerMillion: decimal(cells[6]),
+                longContextCacheWritePerMillion: decimal(cells[7]),
+                longContextOutputPerMillion: decimal(cells[8]))
+            guard valid(price) else { throw OpenAIPricingCatalogError.invalidMarkdown }
+            result[model] = price
+        }
+
+        guard insideStandardTable, sawHeader else {
+            throw OpenAIPricingCatalogError.invalidMarkdown
+        }
+        guard !result.isEmpty else { throw OpenAIPricingCatalogError.emptyCatalog }
+        return result
+    }
+
+    private static func tableCells(_ line: String) -> [String] {
+        let parts = line.split(separator: "|", omittingEmptySubsequences: false)
+        guard parts.count >= 2 else { return [] }
+        return parts.dropFirst().dropLast().map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func normalizedModelID(_ value: String) -> String {
+        let withoutContextNote = value.split(separator: " ", maxSplits: 1).first.map(String.init) ?? value
+        return withoutContextNote.lowercased()
+    }
+
+    private static func isCodexCompatibleModelID(_ value: String) -> Bool {
+        value.hasPrefix("gpt-") || value.hasPrefix("codex-")
+    }
+
+    private static func decimal(_ value: String) -> Decimal? {
+        let cleaned = value
+            .replacingOccurrences(of: "$", with: "")
+            .replacingOccurrences(of: ",", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard cleaned != "-", !cleaned.isEmpty else { return nil }
+        return Decimal(string: cleaned, locale: Locale(identifier: "en_US_POSIX"))
+    }
+
+    private static func valid(_ price: PricingTable.Price) -> Bool {
+        let values = [
+            price.inputPerMillion,
+            price.cachedInputPerMillion,
+            price.cacheWritePerMillion,
+            price.outputPerMillion,
+            price.longContextInputPerMillion,
+            price.longContextCachedInputPerMillion,
+            price.longContextCacheWritePerMillion,
+            price.longContextOutputPerMillion,
+        ].compactMap { $0 }
+        return !values.isEmpty && values.allSatisfy { $0 >= 0 && $0 <= 10_000 }
+    }
+}
+
+actor OpenAIPricingCatalogProvider {
+    static let sourceURL = URL(string: "https://developers.openai.com/api/docs/pricing.md")!
+    static let defaultRefreshInterval: TimeInterval = 24 * 60 * 60
+
+    private struct Cache: Codable, Sendable {
+        var schemaVersion: Int
+        var sourceURL: String
+        var fetchedAt: Date
+        var eTag: String?
+        var lastModified: String?
+        var prices: [String: PricingTable.Price]
+
+        var priceBook: UsageCostPriceBook {
+            let merged = PricingTable.mergedPrices(overrides: prices)
+            let fallback = PricingTable.price(for: "gpt-5.6-sol", in: merged)
+                ?? PricingTable.equivalentPrice
+            return UsageCostPriceBook(
+                version: pricingVersion,
+                priceForModel: { model in PricingTable.price(for: model, in: merged) },
+                equivalentPrice: fallback)
+        }
+
+        private var pricingVersion: String {
+            let source = eTag ?? lastModified ?? ISO8601DateFormatter().string(from: fetchedAt)
+            let token = source.unicodeScalars.map { scalar -> Character in
+                CharacterSet.alphanumerics.contains(scalar) ? Character(String(scalar)) : "-"
+            }
+            let compact = String(token).replacingOccurrences(
+                of: #"-+"#,
+                with: "-",
+                options: .regularExpression)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+            return "openai-docs-\(compact.prefix(48))"
+        }
+    }
+
+    private let cacheURL: URL
+    private let refreshInterval: TimeInterval
+    private let fetch: OpenAIPricingFetcher
+    private var cache: Cache?
+
+    init(
+        cacheURL: URL = OpenAIPricingCatalogProvider.defaultCacheURL,
+        refreshInterval: TimeInterval = OpenAIPricingCatalogProvider.defaultRefreshInterval,
+        fetch: @escaping OpenAIPricingFetcher = OpenAIPricingCatalogProvider.fetchOfficialPricing)
+    {
+        self.cacheURL = cacheURL
+        self.refreshInterval = refreshInterval
+        self.fetch = fetch
+        cache = Self.loadCache(from: cacheURL)
+    }
+
+    func priceBook(now: Date = Date()) async -> UsageCostPriceBook {
+        if let cache, now.timeIntervalSince(cache.fetchedAt) < refreshInterval {
+            return cache.priceBook
+        }
+
+        do {
+            let response = try await fetch(cache?.eTag)
+            if response.statusCode == 304, var cache {
+                cache.fetchedAt = now
+                try save(cache)
+                self.cache = cache
+                return cache.priceBook
+            }
+            guard (200..<300).contains(response.statusCode) else {
+                throw OpenAIPricingCatalogError.invalidStatus(response.statusCode)
+            }
+            guard let markdown = String(data: response.data, encoding: .utf8) else {
+                throw OpenAIPricingCatalogError.invalidMarkdown
+            }
+            let prices = try OpenAIPricingMarkdownParser.parseStandardPrices(markdown)
+            let updated = Cache(
+                schemaVersion: 1,
+                sourceURL: Self.sourceURL.absoluteString,
+                fetchedAt: now,
+                eTag: response.eTag,
+                lastModified: response.lastModified,
+                prices: prices)
+            try save(updated)
+            cache = updated
+            return updated.priceBook
+        } catch {
+            return cache?.priceBook ?? .current
+        }
+    }
+
+    static var defaultCacheURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex-runway", isDirectory: true)
+            .appendingPathComponent("openai-pricing-v1.json")
+    }
+
+    private static func fetchOfficialPricing(eTag: String?) async throws -> OpenAIPricingHTTPResponse {
+        var request = URLRequest(url: sourceURL)
+        request.timeoutInterval = 10
+        request.setValue("text/markdown", forHTTPHeaderField: "Accept")
+        request.setValue("CodexRunway/1", forHTTPHeaderField: "User-Agent")
+        if let eTag { request.setValue(eTag, forHTTPHeaderField: "If-None-Match") }
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let response = response as? HTTPURLResponse else {
+            throw OpenAIPricingCatalogError.invalidResponse
+        }
+        return OpenAIPricingHTTPResponse(
+            statusCode: response.statusCode,
+            data: data,
+            eTag: response.value(forHTTPHeaderField: "ETag"),
+            lastModified: response.value(forHTTPHeaderField: "Last-Modified"))
+    }
+
+    private static func loadCache(from url: URL) -> Cache? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let cache = try? decoder.decode(Cache.self, from: data),
+              cache.schemaVersion == 1,
+              cache.sourceURL == sourceURL.absoluteString,
+              !cache.prices.isEmpty
+        else { return nil }
+        return cache
+    }
+
+    private func save(_ cache: Cache) throws {
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(cache).write(to: cacheURL, options: .atomic)
+    }
+}

--- a/Sources/CodexRunwayCore/UsageCostCacheStore.swift
+++ b/Sources/CodexRunwayCore/UsageCostCacheStore.swift
@@ -12,7 +12,7 @@ public struct UsageCostCacheStore: Sendable {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard let summary = try? decoder.decode(ApiEquivalentSummary.self, from: data),
-              summary.pricingVersion == PricingTable.version
+              PricingTable.isCompatibleCacheVersion(summary.pricingVersion)
         else {
             return nil
         }

--- a/Sources/CodexRunwayCore/UsageCostRepository.swift
+++ b/Sources/CodexRunwayCore/UsageCostRepository.swift
@@ -85,6 +85,7 @@ public actor UsageCostRepository {
         var queries: [ApiCostQuery]
         var calculatedAt: Date
         var policy: UsageCostRefreshPolicy
+        var pricingVersion: String
     }
 
     private struct Flight {
@@ -94,6 +95,8 @@ public actor UsageCostRepository {
     }
 
     private let worker: UsageCostRepositoryWorker
+    private let pricingProvider: OpenAIPricingCatalogProvider?
+    private let fixedPriceBook: UsageCostPriceBook
     private let beforeFlight: (@Sendable () async -> Void)?
     private var inFlight: [RequestKey: Flight] = [:]
     private var sharedFlightHits = 0
@@ -107,8 +110,9 @@ public actor UsageCostRepository {
             codexHome: codexHome,
             databaseURL: Self.defaultDatabaseURL,
             parserVersion: UsageCostRepositoryWorker.currentParserVersion,
-            priceBook: .current,
             calendar: .autoupdatingCurrent)
+        pricingProvider = OpenAIPricingCatalogProvider()
+        fixedPriceBook = .current
         beforeFlight = nil
     }
 
@@ -118,8 +122,9 @@ public actor UsageCostRepository {
             codexHome: codexHome,
             databaseURL: databaseURL,
             parserVersion: UsageCostRepositoryWorker.currentParserVersion,
-            priceBook: .current,
             calendar: .autoupdatingCurrent)
+        pricingProvider = OpenAIPricingCatalogProvider()
+        fixedPriceBook = .current
         beforeFlight = nil
     }
 
@@ -135,8 +140,9 @@ public actor UsageCostRepository {
             codexHome: codexHome,
             databaseURL: databaseURL,
             parserVersion: parserVersion,
-            priceBook: priceBook,
             calendar: calendar)
+        pricingProvider = nil
+        fixedPriceBook = priceBook
         self.beforeFlight = beforeFlight
     }
 
@@ -149,11 +155,18 @@ public actor UsageCostRepository {
         try Task.checkCancellation()
         guard !queries.isEmpty else { return [:] }
         try Self.validateQueries(queries)
+        let priceBook: UsageCostPriceBook
+        if let pricingProvider {
+            priceBook = await pricingProvider.priceBook()
+        } else {
+            priceBook = fixedPriceBook
+        }
         let canonicalQueries = queries.sorted(by: Self.queryOrder)
         let key = RequestKey(
             queries: canonicalQueries,
             calculatedAt: calculatedAt,
-            policy: policy)
+            policy: policy,
+            pricingVersion: priceBook.version)
 
         let waiterID = UUID()
         let flight: Flight
@@ -172,6 +185,7 @@ public actor UsageCostRepository {
                     for: canonicalQueries,
                     calculatedAt: calculatedAt,
                     policy: policy,
+                    priceBook: priceBook,
                     progress: progress)
             }
             flight = Flight(id: UUID(), task: task, waiters: [waiterID])

--- a/Sources/CodexRunwayCore/UsageCostRepositoryWorker.swift
+++ b/Sources/CodexRunwayCore/UsageCostRepositoryWorker.swift
@@ -7,7 +7,6 @@ actor UsageCostRepositoryWorker {
     private let codexHome: URL
     private let databaseURL: URL
     private let parserVersion: Int
-    private let priceBook: UsageCostPriceBook
     private let calendar: Calendar
     private var store: UsageCostIndexStore?
     private var diagnostics = UsageCostRepositoryDiagnostics()
@@ -17,13 +16,11 @@ actor UsageCostRepositoryWorker {
         codexHome: URL,
         databaseURL: URL,
         parserVersion: Int,
-        priceBook: UsageCostPriceBook,
         calendar: Calendar)
     {
         self.codexHome = codexHome
         self.databaseURL = databaseURL
         self.parserVersion = parserVersion
-        self.priceBook = priceBook
         self.calendar = calendar
     }
 
@@ -31,6 +28,7 @@ actor UsageCostRepositoryWorker {
         for queries: [ApiCostQuery],
         calculatedAt: Date,
         policy: UsageCostRefreshPolicy,
+        priceBook: UsageCostPriceBook,
         progress: CostScanProgressReporter? = nil
     ) throws -> [String: ApiEquivalentSummary] {
         try Task.checkCancellation()
@@ -43,6 +41,7 @@ actor UsageCostRepositoryWorker {
                 queries: queries,
                 calculatedAt: calculatedAt,
                 policy: policy,
+                priceBook: priceBook,
                 progress: progress)
         } catch {
             guard try shouldRebuild(after: error) else { throw error }
@@ -51,6 +50,7 @@ actor UsageCostRepositoryWorker {
                 queries: queries,
                 calculatedAt: calculatedAt,
                 policy: policy,
+                priceBook: priceBook,
                 opened: rebuilt,
                 progress: progress)
         }
@@ -64,6 +64,7 @@ actor UsageCostRepositoryWorker {
         queries: [ApiCostQuery],
         calculatedAt: Date,
         policy: UsageCostRefreshPolicy,
+        priceBook: UsageCostPriceBook,
         opened suppliedStore: (store: UsageCostIndexStore, warnings: [String])? = nil,
         progress: CostScanProgressReporter? = nil
     ) throws -> [String: ApiEquivalentSummary] {

--- a/Sources/CodexRunwayCore/UsageCostSummaryBuilder.swift
+++ b/Sources/CodexRunwayCore/UsageCostSummaryBuilder.swift
@@ -11,29 +11,37 @@ enum UsageCostSummaryBuilder {
         let groups = try group(events)
         let modelRows = modelRows(groups.byModel, priceBook: priceBook)
         let totals = try ApiEquivalentTotals.sum(groups.byDay.values)
-        let unknownWarnings = groups.byModel.keys
+        let unknownModels = groups.byModel.keys
             .filter { priceBook.priceForModel($0) == nil }
             .sorted()
-            .map { "unknown-model:\($0)" }
+        let estimatedUSD = estimatedCost(byModel: groups.byModel, priceBook: priceBook)
+        let confidence: ApiEquivalentConfidence
+        if totals.totalTokens == 0 {
+            confidence = .unavailable
+        } else if estimatedUSD == nil {
+            confidence = .tokensOnly
+        } else {
+            confidence = .priced
+        }
         return ApiEquivalentSummary(
             source: totals.totalTokens > 0 ? .localSessions : .unavailable,
-            confidence: totals.totalTokens > 0 ? .priced : .unavailable,
+            confidence: confidence,
             window: window,
-            estimatedUSD: modelRows.compactMap(\.estimatedUSD).reduce(Decimal(0), +),
+            estimatedUSD: estimatedUSD,
             totals: totals,
             dailyRows: dailyRows(groups, priceBook: priceBook),
             modelRows: modelRows,
-            projectRows: projectRows(groups.byProject, priceBook: priceBook),
+            projectRows: try projectRows(groups.byProjectModel, priceBook: priceBook),
             clientRows: [],
             rawCredits: 0,
-            warnings: unknownWarnings + warnings,
+            warnings: unknownModels.map { "unknown-model:\($0)" } + warnings,
             pricingVersion: priceBook.version,
             calculatedAt: calculatedAt)
     }
 
     private struct Groups {
         var byModel: [String: ApiEquivalentTotals] = [:]
-        var byProject: [String: ApiEquivalentTotals] = [:]
+        var byProjectModel: [String: [String: ApiEquivalentTotals]] = [:]
         var byDay: [String: ApiEquivalentTotals] = [:]
         var byDayModel: [String: [String: ApiEquivalentTotals]] = [:]
     }
@@ -56,10 +64,9 @@ enum UsageCostSummaryBuilder {
                 event.model,
                 default: .zero
             ].adding(totals)
-            result.byProject[event.project, default: .zero] = try result.byProject[
-                event.project,
-                default: .zero
-            ].adding(totals)
+            result.byProjectModel[event.project, default: [:]][event.model, default: .zero] =
+                try result.byProjectModel[event.project, default: [:]][event.model, default: .zero]
+                    .adding(totals)
             result.byDay[event.dayKey, default: .zero] = try result.byDay[
                 event.dayKey,
                 default: .zero
@@ -80,27 +87,27 @@ enum UsageCostSummaryBuilder {
             return ApiEquivalentBreakdownRow(
                 name: model,
                 totals: totals,
-                estimatedUSD: priceBook.cost(model: model, totals: totals)
-                    ?? priceBook.equivalentCost(totals: totals),
+                estimatedUSD: priceBook.cost(model: model, totals: totals),
                 rawCredits: 0)
         }
     }
 
     private static func projectRows(
-        _ grouped: [String: ApiEquivalentTotals],
+        _ grouped: [String: [String: ApiEquivalentTotals]],
         priceBook: UsageCostPriceBook
-    ) -> [ApiEquivalentBreakdownRow] {
-        grouped.keys.sorted { lhs, rhs in
-            let left = grouped[lhs]?.totalTokens ?? 0
-            let right = grouped[rhs]?.totalTokens ?? 0
-            return left == right ? lhs < rhs : left > right
-        }.map { project in
-            let totals = grouped[project] ?? .zero
+    ) throws -> [ApiEquivalentBreakdownRow] {
+        let rows = try grouped.map { project, byModel -> ApiEquivalentBreakdownRow in
+            let totals = try ApiEquivalentTotals.sum(byModel.values)
             return ApiEquivalentBreakdownRow(
                 name: project,
                 totals: totals,
-                estimatedUSD: priceBook.equivalentCost(totals: totals),
+                estimatedUSD: estimatedCost(byModel: byModel, priceBook: priceBook),
                 rawCredits: 0)
+        }
+        return rows.sorted { lhs, rhs in
+            lhs.totals.totalTokens == rhs.totals.totalTokens
+                ? lhs.name < rhs.name
+                : lhs.totals.totalTokens > rhs.totals.totalTokens
         }
     }
 
@@ -123,10 +130,14 @@ enum UsageCostSummaryBuilder {
     private static func estimatedCost(
         byModel: [String: ApiEquivalentTotals],
         priceBook: UsageCostPriceBook
-    ) -> Decimal {
-        byModel.reduce(Decimal(0)) { result, item in
-            result + (priceBook.cost(model: item.key, totals: item.value)
-                ?? priceBook.equivalentCost(totals: item.value))
+    ) -> Decimal? {
+        var result = Decimal(0)
+        for item in byModel {
+            guard let cost = priceBook.cost(model: item.key, totals: item.value) else {
+                return nil
+            }
+            result += cost
         }
+        return result
     }
 }

--- a/Tests/CodexRunwayCoreTests/CostScannerTests.swift
+++ b/Tests/CodexRunwayCoreTests/CostScannerTests.swift
@@ -98,7 +98,7 @@ struct CostScannerTests {
         #expect(report.diagnostics.candidateFiles == 2)
     }
 
-    @Test("local API equivalent scans the weekly window and falls back for unknown models")
+    @Test("local API equivalent scans the weekly window without pricing unknown models")
     func localAPIEquivalentUsesWeeklyWindow() throws {
         let root = try TemporaryDirectory()
         let calculatedAt = ISO8601DateFormatter().date(from: "2026-06-30T10:00:00Z")!
@@ -118,7 +118,7 @@ struct CostScannerTests {
 
         #expect(summary.calculatedAt == calculatedAt)
         #expect(summary.source == .localSessions)
-        #expect(summary.confidence == .priced)
+        #expect(summary.confidence == .tokensOnly)
         #expect(summary.totals.uncachedInputTokens == 1_300)
         #expect(summary.totals.cachedInputTokens == 200)
         #expect(summary.totals.outputTokens == 75)
@@ -126,7 +126,7 @@ struct CostScannerTests {
         #expect(summary.dailyRows.map(\.date) == ["2026-06-25", "2026-06-29"])
         #expect(summary.dailyRows[0].estimatedUSD != summary.estimatedUSD)
         #expect(summary.modelRows.map(\.name) == ["gpt-5.3-codex", "unknown-model"])
-        #expect(summary.estimatedUSD ?? 0 > 0)
+        #expect(summary.estimatedUSD == nil)
         #expect(summary.warnings.isEmpty == false)
     }
 
@@ -815,6 +815,30 @@ struct CostScannerTests {
         try store.save(summary)
 
         #expect(store.load() == nil)
+    }
+
+    @Test("cost cache accepts an official dynamic pricing version")
+    func costCacheAcceptsOfficialPricingVersion() throws {
+        let root = try TemporaryDirectory()
+        let cacheURL = root.url.appending(path: "api-equivalent-cost.json")
+        let store = UsageCostCacheStore(cacheURL: cacheURL)
+        let summary = ApiEquivalentSummary(
+            source: .localSessions,
+            confidence: .priced,
+            window: DateInterval(start: Date(timeIntervalSince1970: 0), duration: 60),
+            estimatedUSD: 1,
+            totals: .zero,
+            dailyRows: [],
+            modelRows: [],
+            clientRows: [],
+            rawCredits: 0,
+            warnings: [],
+            pricingVersion: "openai-docs-official-etag",
+            calculatedAt: Date(timeIntervalSince1970: 60))
+
+        try store.save(summary)
+
+        #expect(store.load() == summary)
     }
 
     @Test("cost cache ignores missing or corrupt files")

--- a/Tests/CodexRunwayCoreTests/OpenAIPricingCatalogTests.swift
+++ b/Tests/CodexRunwayCoreTests/OpenAIPricingCatalogTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import CodexRunwayCore
+
+@Suite("OpenAI pricing catalog")
+struct OpenAIPricingCatalogTests {
+    @Test("parses the official Standard pricing Markdown table")
+    func parsesStandardPricingTable() throws {
+        let prices = try OpenAIPricingMarkdownParser.parseStandardPrices(Self.markdown)
+        let sol = try #require(prices["gpt-5.6-sol"])
+        let terra = try #require(prices["gpt-5.6-terra"])
+
+        #expect(sol.inputPerMillion == 5)
+        #expect(sol.cachedInputPerMillion == 0.5)
+        #expect(sol.cacheWritePerMillion == 6.25)
+        #expect(sol.outputPerMillion == 30)
+        #expect(sol.longContextInputPerMillion == 10)
+        #expect(sol.longContextOutputPerMillion == 45)
+        #expect(terra.inputPerMillion == 2)
+        #expect(prices["unrelated-provider"] == nil)
+    }
+
+    @Test("uses a downloaded catalog and writes a last-known-good cache")
+    func downloadsAndCachesCatalog() async throws {
+        let directory = try PricingTestDirectory()
+        let cacheURL = directory.url.appendingPathComponent("pricing.json")
+        let now = Date(timeIntervalSince1970: 1_786_579_200)
+        let provider = OpenAIPricingCatalogProvider(
+            cacheURL: cacheURL,
+            refreshInterval: 0,
+            fetch: { _ in
+                OpenAIPricingHTTPResponse(
+                    statusCode: 200,
+                    data: Data(Self.markdown.utf8),
+                    eTag: #""official-etag""#,
+                    lastModified: "Thu, 13 Aug 2026 04:57:43 GMT")
+            })
+
+        let priceBook = await provider.priceBook(now: now)
+        let oneMillionInput = ApiEquivalentTotals(
+            totalTokens: 1_000_000,
+            uncachedInputTokens: 1_000_000,
+            cachedInputTokens: 0,
+            outputTokens: 0,
+            turns: 1,
+            threads: 0)
+
+        #expect(priceBook.version.hasPrefix("openai-docs-"))
+        #expect(priceBook.cost(model: "gpt-5.6-terra", totals: oneMillionInput) == 2)
+        #expect(FileManager.default.fileExists(atPath: cacheURL.path))
+    }
+
+    @Test("falls back to the cached catalog when refresh fails")
+    func staleCacheFallback() async throws {
+        let directory = try PricingTestDirectory()
+        let cacheURL = directory.url.appendingPathComponent("pricing.json")
+        let fetchedAt = Date(timeIntervalSince1970: 1_786_579_200)
+        let initial = OpenAIPricingCatalogProvider(
+            cacheURL: cacheURL,
+            refreshInterval: 0,
+            fetch: { _ in
+                OpenAIPricingHTTPResponse(
+                    statusCode: 200,
+                    data: Data(Self.markdown.utf8),
+                    eTag: #""cached-etag""#,
+                    lastModified: nil)
+            })
+        _ = await initial.priceBook(now: fetchedAt)
+
+        let offline = OpenAIPricingCatalogProvider(
+            cacheURL: cacheURL,
+            refreshInterval: 0,
+            fetch: { _ in throw URLError(.notConnectedToInternet) })
+        let priceBook = await offline.priceBook(now: fetchedAt.addingTimeInterval(86_400))
+
+        #expect(priceBook.version.hasPrefix("openai-docs-"))
+        #expect(priceBook.priceForModel("gpt-5.6-sol")?.inputPerMillion == 5)
+    }
+
+    @Test("bundled lookup is exact except for dated snapshots")
+    func exactModelLookup() {
+        #expect(PricingTable.price(for: "gpt-5.6-sol")?.inputPerMillion == 5)
+        #expect(PricingTable.price(for: "gpt-5.6-sol-2026-08-13")?.inputPerMillion == 5)
+        #expect(PricingTable.price(for: "gpt-5.6-solstice") == nil)
+        #expect(PricingTable.price(for: "gpt-5.5-pro")?.inputPerMillion == 30)
+    }
+
+    private static let markdown = """
+    # Pricing
+
+    ### Standard pricing data
+
+    | Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | gpt-5.6-sol | $5.00 | $0.50 | $6.25 | $30.00 | $10.00 | $1.00 | $12.50 | $45.00 |
+    | gpt-5.6-terra | $2.00 | $0.20 | $2.50 | $12.00 | $4.00 | $0.40 | $5.00 | $18.00 |
+    | unrelated-provider | $1.00 | $0.10 | - | $2.00 | - | - | - | - |
+
+    ### Batch pricing data
+
+    | Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | gpt-5.6-sol | $2.50 | $0.25 | $3.125 | $15.00 | $5.00 | $0.50 | $6.25 | $22.50 |
+    """
+}
+
+private final class PricingTestDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}

--- a/Tests/CodexRunwayCoreTests/UsageCostRepositoryAggregationTests.swift
+++ b/Tests/CodexRunwayCoreTests/UsageCostRepositoryAggregationTests.swift
@@ -261,4 +261,40 @@ struct UsageCostRepositoryAggregationTests {
         #expect(diagnostics.bytesRead == 0)
         #expect(diagnostics.rebuiltFiles == 0)
     }
+
+    @Test("project cost sums each model price instead of using one equivalent rate")
+    func projectCostIsModelAware() async throws {
+        let fixture = try RepositoryFixture()
+        let contents = """
+        {"timestamp":"2026-06-29T00:00:00Z","type":"session_meta","payload":{"cwd":"/Users/me/dev/codex-runway"}}
+        \(tokenLine(timestamp: "2026-06-29T01:00:00Z", input: 1_000_000, output: 0, model: "gpt-5.6-sol"))
+        \(tokenLine(timestamp: "2026-06-29T02:00:00Z", input: 1_000_000, output: 0, model: "gpt-5.6-luna"))
+        """
+        try fixture.write(contents, basename: "rollout-project-models.jsonl")
+        let prices = [
+            "gpt-5.6-sol": PricingTable.Price(
+                inputPerMillion: 5,
+                cachedInputPerMillion: 0.5,
+                outputPerMillion: 30),
+            "gpt-5.6-luna": PricingTable.Price(
+                inputPerMillion: 0.2,
+                cachedInputPerMillion: 0.02,
+                outputPerMillion: 1.2),
+        ]
+        let priceBook = UsageCostPriceBook(
+            version: "model-aware",
+            priceForModel: { prices[$0] },
+            equivalentPrice: PricingTable.Price(
+                inputPerMillion: 999,
+                cachedInputPerMillion: 999,
+                outputPerMillion: 999))
+
+        let summary = try #require(try await fixture.repository(priceBook: priceBook).summaries(
+            for: [fullWindowQuery()], calculatedAt: fixedNow, policy: .ifChanged)["full"])
+
+        #expect(summary.projectRows.count == 1)
+        #expect(summary.projectRows[0].name == "codex-runway")
+        #expect(summary.projectRows[0].estimatedUSD == 5.2)
+        #expect(summary.estimatedUSD == 5.2)
+    }
 }

--- a/Tests/CodexRunwayTests/RunwayModelRefreshTests.swift
+++ b/Tests/CodexRunwayTests/RunwayModelRefreshTests.swift
@@ -384,6 +384,56 @@ struct RunwayModelRefreshTests {
         #expect(await recorder.captureCount == 1)
     }
 
+    @Test("current cycle detail refreshes a snapshot whose elapsed end is stale")
+    func currentCycleDetailRefreshesStaleElapsedSnapshot() async throws {
+        let recorder = CostBatchRecorder()
+        let settings = RunwaySettings(store: PreferencesStore(defaults: scopedDefaults()))
+        settings.updateApiCostSummaryRange(.current)
+        let quota = Self.quotaSnapshot(secondaryReset: Date().addingTimeInterval(6 * 24 * 3_600))
+        let services = RunwayModelServices(
+            loadValidAuth: { _, _ in Self.auth() },
+            fetchQuota: { _ in quota },
+            fetchResetCredits: { _ in ResetCreditsSnapshot(availableCount: 0, credits: [], updatedAt: Date()) },
+            fetchRateLimitResetToday: {
+                RateLimitResetTodaySnapshot(state: .no, fetchedAt: Date())
+            },
+            scanAPIEquivalent: { queries, now, policy, _ in
+                await recorder.record(queries: queries, now: now, policy: policy)
+                let isFirstScan = await recorder.captureCount == 1
+                return Dictionary(uniqueKeysWithValues: queries.map { query in
+                    let window = isFirstScan
+                        ? DateInterval(
+                            start: query.window.start,
+                            end: query.window.end.addingTimeInterval(-3_600))
+                        : query.window
+                    return (query.id, Self.costSummary(window: window, calculatedAt: now))
+                })
+            },
+            fetchDailyWorkspaceUsage: { _, _, _, window, now in
+                Self.costSummary(window: window, calculatedAt: now)
+            },
+            fetchCodexProfileTokenUsage: { _ in CodexProfileTokenUsage(dailyTokens: [:]) },
+            dryRunSessions: {
+                SessionRepairReport(
+                    missingIndexIDs: [],
+                    orphanIndexIDs: [],
+                    duplicateIndexIDs: [],
+                    staleTitleIDs: [],
+                    backupPath: nil,
+                    plannedEntries: 0)
+            },
+            scanRecentSessions: { _ in SessionActivitySummary(items: []) })
+        let model = makeModel(settings: settings, services: services)
+
+        model.refreshCost()
+        _ = try await recorder.waitForBatch()
+        try await waitForCostRefresh(in: model)
+
+        _ = try await model.queryCurrentCycleCost()
+
+        #expect(await recorder.captureCount == 2)
+    }
+
     @Test("previous cycle API cost summary scans the full previous quota weekly range")
     func previousCycleAPICostSummaryScansFullPreviousQuotaWindow() async throws {
         let recorder = CostBatchRecorder()


### PR DESCRIPTION
## 修复背景

API 等价成本详情存在两类问题：

1. 顶部总成本按模型分组计价，但项目明细统一使用写死的 Sol 等价价格。`gpt-5.6-sol` 又会被模糊的 `contains("gpt-5")` 分支匹配成通用 GPT-5 价格，导致同一批 Tokens 在顶部和项目维度得到不同金额。
2. 本周期详情只校验缓存窗口的起点，没有要求缓存终点接近当前时间，因此可能复用同周期内较早生成的快照。本周期如果恰好在今天中途重置，本来就可能小于今日，但旧快照会让差异进一步扩大且界面没有展示实际窗口。

## 修改内容

- 从 OpenAI 官方价格 Markdown `https://developers.openai.com/api/docs/pricing.md` 读取 Standard pricing data，仅保留 Codex 可用的 OpenAI 模型。
- 官方价格缓存 24 小时到 `~/.codex-runway/openai-pricing-v1.json`，支持 ETag；网络、格式或写入失败时回退到最近一次成功缓存，再回退到带版本日期的本地价格表。
- 使用精确模型 ID 和日期快照后缀匹配，移除 `contains("gpt-5")` 模糊匹配。
- 项目、日期和总计均按实际模型分别计价，不再统一套用 Sol 价格。
- 未知模型不再估算精确费用，降级为 tokens-only，并保留 `unknown-model` warning。
- 价格版本加入汇总请求键；价格变化时重新汇总并清理 UI 详情缓存。
- 本周期缓存同时校验起点和终点，终点超过 2 分钟即重新查询。
- 费用详情顶部显示实际统计起止时间，明确今日中途重置等情况。

## 验证

- `swift build --target CodexRunwayCore`
- `swift build --target CodexRunwayCostBenchmark`
- CodexRunwayCore 测试：313 项通过
- CodexRunway UI 测试：101 项通过
- 新增官方价格解析、缓存回退、精确模型匹配、项目混合模型计价、未知模型降级和旧周期快照回归测试
- `git diff --check`

未启动应用、预览服务或浏览器进行验收。