### PR TITLE
fix: 修正菜单栏进度条内容居中

### DIFF
--- a/Sources/CodexRunway/StatusBarContentLayout.swift
+++ b/Sources/CodexRunway/StatusBarContentLayout.swift
@@ -79,7 +79,7 @@ struct StatusBarContentLayout {
             // Elongated iOS-style body + terminal + padding around the center label.
             return min(150, max(72, textWidth(batteryDetail(for: onlyMeter), font: batteryFont) + 32))
         case .meters:
-            return renderPlan.meters.isEmpty ? 70 : totalWidth(meterColumnWidths, gap: 6)
+            return renderPlan.meters.isEmpty ? 70 : contentWidth(meterColumnWidths, gap: 6)
         case .rings:
             return CGFloat(max(1, renderPlan.meters.count) * 24 + 4)
         }
@@ -107,6 +107,14 @@ struct StatusBarContentLayout {
 
     var meterTextFont: NSFont {
         .systemFont(ofSize: 8.5, weight: .semibold)
+    }
+
+    var meterBarWidth: CGFloat {
+        40
+    }
+
+    var meterTextGap: CGFloat {
+        4
     }
 
     var ringFont: NSFont {
@@ -142,11 +150,15 @@ struct StatusBarContentLayout {
 
     var meterColumnWidths: [CGFloat] {
         renderPlan.columns.map { column in
-            let maximumTextWidth = column.map {
-                textWidth(meterCaption(for: $0), font: meterTextFont)
-            }.max() ?? 0
-            return min(166, max(96, maximumTextWidth + 52))
+            let maximumContentWidth = column.map { meterContentWidth(for: $0) }.max() ?? 0
+            return min(166, max(64, maximumContentWidth))
         }
+    }
+
+    func meterContentWidth(for meter: QuotaMeter) -> CGFloat {
+        meterBarWidth
+            + meterTextGap
+            + textWidth(meterCaption(for: meter), font: meterTextFont)
     }
 
     func countdownCaption(for meter: QuotaMeter) -> String {
@@ -227,7 +239,11 @@ struct StatusBarContentLayout {
     }
 
     private func totalWidth(_ widths: [CGFloat], gap: CGFloat) -> CGFloat {
-        widths.reduce(8, +) + CGFloat(max(0, widths.count - 1)) * gap
+        contentWidth(widths, gap: gap) + 8
+    }
+
+    private func contentWidth(_ widths: [CGFloat], gap: CGFloat) -> CGFloat {
+        widths.reduce(0, +) + CGFloat(max(0, widths.count - 1)) * gap
     }
 
     private func textWidth(_ text: String, font: NSFont) -> CGFloat {

--- a/Sources/CodexRunway/StatusBarContentView.swift
+++ b/Sources/CodexRunway/StatusBarContentView.swift
@@ -171,7 +171,7 @@ final class StatusBarContentView: NSView {
     }
 
     private func drawMeter(_ meter: QuotaMeter, row: NSRect) {
-        let barWidth = min(40, row.width * 0.36)
+        let barWidth = min(layout.meterBarWidth, row.width)
         let barRect = NSRect(x: row.minX, y: row.midY - 2.5, width: barWidth, height: 5)
         let background = NSBezierPath(roundedRect: barRect, xRadius: 2.5, yRadius: 2.5)
         NSColor.separatorColor.withAlphaComponent(0.45).setFill()
@@ -185,9 +185,9 @@ final class StatusBarContentView: NSView {
             height: barRect.height)
         NSBezierPath(roundedRect: fillRect, xRadius: 2.5, yRadius: 2.5).fill(with: meterColor(meter), alpha: 0.95)
         let textRect = NSRect(
-            x: barRect.maxX + 4,
+            x: barRect.maxX + layout.meterTextGap,
             y: row.minY,
-            width: max(20, row.maxX - barRect.maxX - 4),
+            width: max(0, row.maxX - barRect.maxX - layout.meterTextGap),
             height: row.height)
         drawLine(layout.meterCaption(for: meter), rect: textRect)
     }

--- a/Tests/CodexRunwayTests/StatusBarRenderPlanTests.swift
+++ b/Tests/CodexRunwayTests/StatusBarRenderPlanTests.swift
@@ -169,6 +169,24 @@ struct StatusBarRenderPlanTests {
         }
     }
 
+    @Test("single meter column fits its visible bar and caption without trailing slack")
+    func singleMeterColumnFitsVisibleContent() throws {
+        let weekly = meter(title: "每周", usedPercent: 10, windowMinutes: 10_080)
+        let displayMinute = Int(Date().timeIntervalSince1970 / 60)
+        let layout = StatusBarContentLayout(state: StatusBarContentState(
+            configuration: StatusBarContentState.Configuration(
+                preferences: preferences(style: .meters),
+                language: .simplifiedChinese),
+            content: StatusBarContentState.Content(
+                text: "",
+                meters: [weekly],
+                displayMinute: displayMinute)))
+
+        let columnWidth = try #require(layout.meterColumnWidths.first)
+        #expect(abs(columnWidth - layout.meterContentWidth(for: weekly)) < 0.001)
+        #expect(layout.preferredWidth == columnWidth)
+    }
+
     @Test("all status bar styles render weekly-only and model-specific layouts")
     @MainActor
     func allStylesRenderVariableQuotaCounts() throws {


### PR DESCRIPTION
## 修复背景

菜单栏“进度条 + 文案”样式虽然整体状态项位于系统分配区域的中央，但内部列宽固定为至少 96pt，进度条贴左绘制，文案也从左侧开始排列。较短文案无法占满固定列宽时，剩余空间全部堆在右侧，导致可见内容组明显偏左、左右留白不对称。

这是状态栏绘制层的布局问题，不涉及配额数据、刷新流程、账号状态或其他显示样式。

## 修改内容

- 使用固定 40pt 进度条宽度、4pt 文案间距和实际文案宽度共同计算列宽。
- 让绘制时的进度条宽度与布局测量使用同一组指标，避免测量和渲染结果不一致。
- 移除该显示样式额外添加的应用层水平留白，只保留 macOS 状态项自身的对称系统边距。
- 保留多配额列的最大宽度与截断上限，不改变现有分组和展示顺序。
- 新增单配额回归测试，确保列宽紧贴可见进度条与文案，不再产生右侧尾部空白。

## 验证

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test`：CodexRunway UI 测试 105 项、Core 测试 341 项，共 446 项通过。
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build -c release --product CodexRunway --triple arm64-apple-macosx12.0`
- 独立 Bundle ID、独立偏好和独立单实例锁的预览包已与当前 Release 并行启动，修改后的居中效果已实际确认。
- `git diff --check`
