### PR TITLE
修复从详情页返回后跳到首页顶部的问题

### DIFF
--- a/Sources/CodexRunway/PolishedScrollView.swift
+++ b/Sources/CodexRunway/PolishedScrollView.swift
@@ -1,6 +1,14 @@
 import AppKit
 import SwiftUI
 
+/// Transient vertical position shared by scroll views that are recreated inside one
+/// presentation. The value is intentionally not published: capturing a position while
+/// a view is dismantled must not trigger a redraw of the surrounding SwiftUI tree.
+@MainActor
+final class PolishedScrollPosition: ObservableObject {
+    fileprivate var verticalOffset: CGFloat = 0
+}
+
 struct PolishedScrollView<Content: View>: View {
     private let content: Content
     private let verticalPadding: CGFloat
@@ -10,25 +18,30 @@ struct PolishedScrollView<Content: View>: View {
     private let remasureToken: AnyHashable
     /// Thin overlay knob that fades away when idle. Off for the popover, on for settings.
     private let showsOverlayScroller: Bool
+    /// Optional position whose lifetime is owned by the caller.
+    private let scrollPosition: PolishedScrollPosition?
 
     init(
         verticalPadding: CGFloat = 8,
         fadesEdges: Bool = true,
         remasureToken: AnyHashable = 0,
         showsOverlayScroller: Bool = false,
+        scrollPosition: PolishedScrollPosition? = nil,
         @ViewBuilder content: () -> Content)
     {
         self.verticalPadding = verticalPadding
         self.fadesEdges = fadesEdges
         self.remasureToken = remasureToken
         self.showsOverlayScroller = showsOverlayScroller
+        self.scrollPosition = scrollPosition
         self.content = content()
     }
 
     var body: some View {
         let scroll = HiddenScrollerScrollView(
             remasureToken: remasureToken,
-            showsOverlayScroller: showsOverlayScroller)
+            showsOverlayScroller: showsOverlayScroller,
+            scrollPosition: scrollPosition)
         {
             content
                 .padding(.vertical, verticalPadding)
@@ -56,19 +69,22 @@ private struct HiddenScrollerScrollView<Content: View>: NSViewRepresentable {
     let content: Content
     let remasureToken: AnyHashable
     let showsOverlayScroller: Bool
+    let scrollPosition: PolishedScrollPosition?
 
     init(
         remasureToken: AnyHashable,
         showsOverlayScroller: Bool,
+        scrollPosition: PolishedScrollPosition?,
         @ViewBuilder content: () -> Content)
     {
         self.remasureToken = remasureToken
         self.showsOverlayScroller = showsOverlayScroller
+        self.scrollPosition = scrollPosition
         self.content = content()
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(scrollPosition: scrollPosition)
     }
 
     /// The nested NSHostingView is a separate SwiftUI root: custom environment keys do
@@ -99,8 +115,10 @@ private struct HiddenScrollerScrollView<Content: View>: NSViewRepresentable {
         scrollView.onLayout = { [weak scrollView, weak hostingView] in
             guard let scrollView, let hostingView else { return }
             resize(hostingView, in: scrollView, coordinator: context.coordinator, force: false)
+            restoreScrollPosition(in: scrollView, coordinator: context.coordinator)
         }
         resize(hostingView, in: scrollView, coordinator: context.coordinator, force: true)
+        restoreScrollPosition(in: scrollView, coordinator: context.coordinator)
         return scrollView
     }
 
@@ -119,12 +137,21 @@ private struct HiddenScrollerScrollView<Content: View>: NSViewRepresentable {
         // longer strings wrap and grow instead of staying clipped at the old height.
         if languageChanged {
             resize(hostingView, in: scrollView, coordinator: coordinator, force: true)
+            restoreScrollPosition(in: scrollView, coordinator: coordinator)
             return
         }
         coordinator.throttleProbe { [weak scrollView, weak hostingView] in
             guard let scrollView, let hostingView else { return }
             resize(hostingView, in: scrollView, coordinator: coordinator, force: true)
+            restoreScrollPosition(in: scrollView, coordinator: coordinator)
         }
+    }
+
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        guard let scrollPosition = coordinator.scrollPosition else { return }
+        scrollPosition.verticalOffset = clampedVerticalOffset(
+            scrollView.documentVisibleRect.minY,
+            in: scrollView)
     }
 
     private func applyScroller(_ scrollView: NSScrollView) {
@@ -200,8 +227,28 @@ private struct HiddenScrollerScrollView<Content: View>: NSViewRepresentable {
         coordinator.lastHeight = height
     }
 
+    private func restoreScrollPosition(in scrollView: NSScrollView, coordinator: Coordinator) {
+        guard coordinator.needsScrollRestore, let scrollPosition = coordinator.scrollPosition else { return }
+        let viewportHeight = scrollView.contentSize.height
+        guard viewportHeight > 0, scrollView.documentView != nil else { return }
+
+        let offset = Self.clampedVerticalOffset(scrollPosition.verticalOffset, in: scrollView)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: offset))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        scrollPosition.verticalOffset = offset
+        coordinator.needsScrollRestore = false
+    }
+
+    private static func clampedVerticalOffset(_ offset: CGFloat, in scrollView: NSScrollView) -> CGFloat {
+        let documentHeight = scrollView.documentView?.frame.height ?? 0
+        let maximumOffset = max(0, documentHeight - scrollView.contentSize.height)
+        return min(max(0, offset), maximumOffset)
+    }
+
     @MainActor
     final class Coordinator {
+        let scrollPosition: PolishedScrollPosition?
+        var needsScrollRestore: Bool
         var lastWidth: CGFloat = 0
         var lastHeight: CGFloat = 0
         var lastRemasureToken: AnyHashable?
@@ -210,6 +257,11 @@ private struct HiddenScrollerScrollView<Content: View>: NSViewRepresentable {
         private let probeInterval: TimeInterval = 0.1
         private var lastProbeAt: Date?
         private var pendingProbe: (() -> Void)?
+
+        init(scrollPosition: PolishedScrollPosition?) {
+            self.scrollPosition = scrollPosition
+            self.needsScrollRestore = scrollPosition != nil
+        }
 
         /// Leading + trailing throttle: probe immediately when idle, and collapse a
         /// publish burst into a single trailing probe.

--- a/Sources/CodexRunway/RunwayPopoverView.swift
+++ b/Sources/CodexRunway/RunwayPopoverView.swift
@@ -46,6 +46,7 @@ struct RunwayPopoverView: View {
     @State private var detailPage: RunwaySidePanel?
     @State private var apiCostDetailRange = ApiCostSummaryRange.today
     @State private var panelHeight: CGFloat
+    @StateObject private var mainScrollPosition = PolishedScrollPosition()
     private var l10n: L10n { settings.l10n }
     private var visibleSections: [RunwayMainPanelSection] {
         RunwayMainPanelSections.orderedVisible(
@@ -160,7 +161,11 @@ struct RunwayPopoverView: View {
     }
 
     private var mainContent: some View {
-        PolishedScrollView(verticalPadding: 4, remasureToken: l10n.language) {
+        PolishedScrollView(
+            verticalPadding: 4,
+            remasureToken: l10n.language,
+            scrollPosition: mainScrollPosition)
+        {
             VStack(alignment: .leading, spacing: 0) {
                 if showsTierBadgeGallery {
                     sectionBlock(isFirst: true) {

--- a/Tests/CodexRunwayTests/PolishedScrollPositionTests.swift
+++ b/Tests/CodexRunwayTests/PolishedScrollPositionTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import CodexRunway
+
+@Suite("Polished scroll position")
+struct PolishedScrollPositionTests {
+    @Test("recreated scroll view restores position within one presentation")
+    @MainActor
+    func restoresPositionAfterDetailRoundTrip() {
+        let position = PolishedScrollPosition()
+        let host = makeHost(position: position)
+        settle(host)
+
+        let original = requireScrollView(in: host)
+        original.contentView.scroll(to: NSPoint(x: 0, y: 180))
+        original.reflectScrolledClipView(original.contentView)
+        let expected = original.documentVisibleRect.minY
+        #expect(expected > 0)
+
+        host.rootView = AnyView(detailView)
+        settle(host)
+        #expect(collectScrollViews(in: host).isEmpty)
+        host.rootView = homeView(position: position)
+        settle(host)
+
+        let restored = requireScrollView(in: host)
+        #expect(restored !== original)
+        #expect(abs(restored.documentVisibleRect.minY - expected) <= 1)
+    }
+
+    @Test("new presentation starts at the top")
+    @MainActor
+    func newPresentationStartsAtTop() {
+        let oldPosition = PolishedScrollPosition()
+        let host = makeHost(position: oldPosition)
+        settle(host)
+
+        let original = requireScrollView(in: host)
+        original.contentView.scroll(to: NSPoint(x: 0, y: 180))
+        original.reflectScrolledClipView(original.contentView)
+        #expect(original.documentVisibleRect.minY > 0)
+
+        let reopenedHost = makeHost(position: PolishedScrollPosition())
+        settle(reopenedHost)
+
+        let reopened = requireScrollView(in: reopenedHost)
+        #expect(reopened !== original)
+        #expect(abs(reopened.documentVisibleRect.minY) <= 1)
+    }
+
+    @MainActor
+    private func makeHost(position: PolishedScrollPosition) -> NSHostingView<AnyView> {
+        let host = NSHostingView(rootView: homeView(position: position))
+        host.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+        return host
+    }
+
+    @MainActor
+    private func homeView(position: PolishedScrollPosition) -> AnyView {
+        AnyView(
+            PolishedScrollView(
+                verticalPadding: 0,
+                fadesEdges: false,
+                scrollPosition: position)
+            {
+                VStack(spacing: 0) {
+                    ForEach(0..<40, id: \.self) { row in
+                        Text("row \(row)")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .frame(height: 28)
+                    }
+                }
+            }
+            .frame(width: 320, height: 180))
+    }
+
+    private var detailView: some View {
+        Text("API cost detail")
+            .frame(width: 320, height: 180)
+    }
+
+    @MainActor
+    private func settle(_ host: NSHostingView<AnyView>) {
+        host.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        host.layoutSubtreeIfNeeded()
+    }
+
+    @MainActor
+    private func requireScrollView(in host: NSView) -> NSScrollView {
+        guard let scrollView = collectScrollViews(in: host).first else {
+            Issue.record("Expected a scroll view")
+            fatalError("Expected a scroll view")
+        }
+        return scrollView
+    }
+
+    @MainActor
+    private func collectScrollViews(in view: NSView) -> [NSScrollView] {
+        var found: [NSScrollView] = []
+        if let scrollView = view as? NSScrollView {
+            found.append(scrollView)
+        }
+        for child in view.subviews {
+            found.append(contentsOf: collectScrollViews(in: child))
+        }
+        return found
+    }
+}


### PR DESCRIPTION
## 问题

在首页往下滑后，点进“API 等价成本”等详情页，再点击返回，页面会直接跳回首页顶部。

## 修改

现在从详情页返回时，会回到刚才浏览的位置。

如果关闭整个面板后再重新打开，仍然会从首页顶部开始。

另外增加了两个测试，分别检查：

- 从详情页返回后，位置保持不变
- 关闭面板再打开后，从顶部开始

## 测试

- 新增的两个测试均通过
- Release 版本编译通过
- 完整测试中，只有仓库原有的俄语标签宽度测试失败，其余通过
- 已在本机实际操作确认问题修复