### PR TITLE
fix: 修复弹窗在白色背景上文字看不清的问题

### DIFF
--- a/Sources/CodexRunway/MainPanelMockRender.swift
+++ b/Sources/CodexRunway/MainPanelMockRender.swift
@@ -150,7 +150,6 @@ enum MainPanelMockRender {
             openGitHub: {},
             openControlPanel: { _ in },
             initialDetailPage: page.sidePanel)
-            .background(Color(nsColor: .windowBackgroundColor))
 
         let host = NSHostingView(rootView: AnyView(root))
         host.appearance = appearance.nsAppearance

--- a/Sources/CodexRunway/RunwayPopoverView.swift
+++ b/Sources/CodexRunway/RunwayPopoverView.swift
@@ -141,6 +141,7 @@ struct RunwayPopoverView: View {
             }
         }
         .frame(width: Self.panelSize.width, height: panelHeight, alignment: .topLeading)
+        .background(RunwaySurface.panel)
         .overlay(alignment: .bottom) {
             MainPanelResizeHandle(
                 panelHeight: $panelHeight,

--- a/Sources/CodexRunway/RunwaySurface.swift
+++ b/Sources/CodexRunway/RunwaySurface.swift
@@ -21,6 +21,9 @@ enum RunwaySurface {
 
     // MARK: Surfaces
 
+    /// Keep panel contrast independent of windows behind the native popover.
+    static let panel = Color(nsColor: .windowBackgroundColor)
+
     /// Cards and interactive rows sitting on the panel.
     static let raised = dynamic(
         light: NSColor.black.withAlphaComponent(0.045),
@@ -63,7 +66,7 @@ enum RunwaySurface {
 }
 
 /// Card chrome per scheme: light gets a translucent gray wash that blends into
-/// the popover material — no outline, no shadow (both read as clutter there);
+/// the panel background — no outline, no shadow (both read as clutter there);
 /// dark keeps translucent fills with a hairline stroke carrying the elevation.
 struct RunwayCardSurface: ViewModifier {
     enum Kind {

--- a/Sources/CodexRunway/TokenUsageHeatmapView.swift
+++ b/Sources/CodexRunway/TokenUsageHeatmapView.swift
@@ -473,7 +473,7 @@ struct TokenUsageHeatmapView: View {
             for label in snapshot.monthLabels {
                 let text = Text(monthTitle(label.month))
                     .font(.caption2)
-                    .foregroundColor(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundColor(Color(nsColor: .secondaryLabelColor))
                 context.draw(
                     context.resolve(text),
                     at: CGPoint(x: CGFloat(label.weekIndex) * step, y: 0),
@@ -1009,7 +1009,7 @@ private struct TokenUsageTrendChartView: View {
             Text("0")
         }
         .font(.system(size: 9, weight: .regular, design: .monospaced))
-        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
         .padding(.trailing, 4)
     }
 
@@ -1021,7 +1021,7 @@ private struct TokenUsageTrendChartView: View {
                 let x = layout.xPosition(for: label.pointIndex)
                 let text = Text(label.title)
                     .font(.caption2)
-                    .foregroundColor(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundColor(Color(nsColor: .secondaryLabelColor))
                 context.draw(context.resolve(text), at: CGPoint(x: x, y: 0), anchor: .top)
             }
         }

--- a/Tests/CodexRunwayTests/MainPanelAppearanceTests.swift
+++ b/Tests/CodexRunwayTests/MainPanelAppearanceTests.swift
@@ -1,0 +1,72 @@
+import AppKit
+import Testing
+@testable import CodexRunway
+
+@Suite("Main panel appearance")
+struct MainPanelAppearanceTests {
+    @Test("main and detail panels paint an opaque background in both appearances")
+    @MainActor
+    func panelBackgroundDoesNotRevealTheDesktop() throws {
+        for page in [MainPanelMockRender.Page.main, .apiCost] {
+            for appearance in MainPanelMockRender.Appearance.allCases {
+                let colors = try marginColors(page: page, appearance: appearance)
+                for color in colors {
+                    // An opaque panel has the same result over white and black
+                    // windows. Do not supply an extra background in the renderer:
+                    // it must capture the surface painted by the shipped root.
+                    #expect(color.alphaComponent >= 0.99)
+                }
+            }
+        }
+    }
+
+    @Test("main and detail panel backgrounds follow light and dark appearance")
+    @MainActor
+    func panelBackgroundFollowsAppearance() throws {
+        for page in [MainPanelMockRender.Page.main, .apiCost] {
+            let light = try #require(marginColors(page: page, appearance: .light).first)
+            let dark = try #require(marginColors(page: page, appearance: .dark).first)
+
+            // Check the theme relationship, not a particular macOS RGB value.
+            #expect(luminance(light) > luminance(dark) + 0.25)
+        }
+    }
+
+    @MainActor
+    private func marginColors(
+        page: MainPanelMockRender.Page,
+        appearance: MainPanelMockRender.Appearance) throws -> [NSColor]
+    {
+        let data = try MainPanelMockRender.render(
+            page: page,
+            appearance: appearance,
+            language: .simplifiedChinese)
+        let image = try #require(NSBitmapImageRep(data: data))
+        #expect(image.pixelsWide > 100)
+        #expect(image.pixelsHigh > 100)
+
+        // Both pages have 16-point horizontal content padding. Sample inside
+        // that margin at several heights, clear of text and the resize handle.
+        var colors: [NSColor] = []
+        for xFraction in [0.02, 0.98] {
+            for yFraction in [0.02, 0.5, 0.97] {
+                let x = Int(Double(image.pixelsWide) * xFraction)
+                let y = Int(Double(image.pixelsHigh) * yFraction)
+                let color = try #require(image.colorAt(x: x, y: y)?.usingColorSpace(.sRGB))
+                colors.append(color)
+            }
+        }
+        return colors
+    }
+
+    private func luminance(_ color: NSColor) -> CGFloat {
+        func linear(_ component: CGFloat) -> CGFloat {
+            component <= 0.04045
+                ? component / 12.92
+                : pow((component + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(color.redComponent)
+            + 0.7152 * linear(color.greenComponent)
+            + 0.0722 * linear(color.blueComponent)
+    }
+}


### PR DESCRIPTION
## 问题

弹窗叠在白色网页等浅色窗口上时，半透明背景会被衬成中灰色，部分说明文字和图表坐标很难辨认。

另外，测试截图单独添加了不透明底色，真实弹窗却没有，所以原来的截图检查没有覆盖这个问题。

## 修改

- 为真实弹窗添加随浅色、深色主题切换的不透明底色，首页和详情页共用。
- 提高图表刻度和月份文字的对比度。
- 移除测试截图独有的底色，增加首页和详情页的背景不透明度、浅深色主题测试。

没有修改账户、统计计算或滚动位置逻辑。

## 验证

- 外观、滚动位置、面板尺寸和图表相关的 19 项测试通过。
- 新增外观测试在修复前失败，修复后通过；已检查浅色、深色的热力图和柱状图预览。
- 全量 607 项测试中，606 项通过，1 项俄文设置页宽度测试失败：`ControlPanelTabBarTests.windowAndTabsGrowForLocalizedTitles`，测得 685，断言要求至少 722。该测试及对应布局代码未在本次修改中改动。
<img width="396" height="475" alt="image" src="https://github.com/user-attachments/assets/8b118c7a-272b-4840-80fc-b3264c29cb50" />
<img width="392" height="465" alt="image" src="https://github.com/user-attachments/assets/5326103d-4058-4610-9ade-8025b16d6902" />


