### PR TITLE
改善状态栏在浅色和深色模式下的显示

### DIFF
--- a/Sources/CodexRunway/StatusBarContentView.swift
+++ b/Sources/CodexRunway/StatusBarContentView.swift
@@ -55,6 +55,11 @@ final class StatusBarContentView: NSView {
         syncSheenAnimation()
     }
 
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
     }
@@ -174,7 +179,7 @@ final class StatusBarContentView: NSView {
         let barWidth = min(layout.meterBarWidth, row.width)
         let barRect = NSRect(x: row.minX, y: row.midY - 2.5, width: barWidth, height: 5)
         let background = NSBezierPath(roundedRect: barRect, xRadius: 2.5, yRadius: 2.5)
-        NSColor.separatorColor.withAlphaComponent(0.45).setFill()
+        palette.track.setFill()
         background.fill()
 
         let percent = CGFloat(meter.remainingPercent) / 100
@@ -183,7 +188,7 @@ final class StatusBarContentView: NSView {
             y: barRect.minY,
             width: barRect.width * percent,
             height: barRect.height)
-        NSBezierPath(roundedRect: fillRect, xRadius: 2.5, yRadius: 2.5).fill(with: meterColor(meter), alpha: 0.95)
+        NSBezierPath(roundedRect: fillRect, xRadius: 2.5, yRadius: 2.5).fill(with: meterColor(meter), alpha: 1)
         let textRect = NSRect(
             x: barRect.maxX + layout.meterTextGap,
             y: row.minY,
@@ -212,7 +217,7 @@ final class StatusBarContentView: NSView {
         let track = NSBezierPath()
         track.appendArc(withCenter: center, radius: radius, startAngle: 0, endAngle: 360)
         track.lineWidth = 2.5
-        NSColor.separatorColor.withAlphaComponent(0.35).setStroke()
+        palette.track.setStroke()
         track.stroke()
 
         if let meter {
@@ -380,17 +385,12 @@ final class StatusBarContentView: NSView {
 
     // MARK: - Shared helpers
 
+    private var palette: StatusBarPalette {
+        StatusBarPalette(appearance: effectiveAppearance)
+    }
+
     private func meterColor(_ meter: QuotaMeter?) -> NSColor {
-        switch meter?.health {
-        case .green:
-            return .systemGreen
-        case .yellow:
-            return .systemYellow
-        case .red:
-            return .systemRed
-        case nil:
-            return .tertiaryLabelColor
-        }
+        palette.color(for: meter?.health)
     }
 
     private func drawCentered(_ text: String, font: NSFont, rect: NSRect, color: NSColor) {
@@ -416,6 +416,38 @@ final class StatusBarContentView: NSView {
             .paragraphStyle: paragraph,
         ]
         text.draw(in: rect, withAttributes: attributes)
+    }
+}
+
+/// Saturated ink on light menu bars, brighter colors on dark menu bars.
+struct StatusBarPalette {
+    let isDark: Bool
+
+    init(appearance: NSAppearance) {
+        isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+    }
+
+    var track: NSColor {
+        (isDark ? NSColor.white : NSColor.black).withAlphaComponent(isDark ? 0.28 : 0.24)
+    }
+
+    func color(for health: QuotaHealth?) -> NSColor {
+        switch health {
+        case .green:
+            return isDark
+                ? NSColor(srgbRed: 0.20, green: 0.87, blue: 0.40, alpha: 1)
+                : NSColor(srgbRed: 0.06, green: 0.43, blue: 0.18, alpha: 1)
+        case .yellow:
+            return isDark
+                ? NSColor(srgbRed: 1, green: 0.80, blue: 0.20, alpha: 1)
+                : NSColor(srgbRed: 0.65, green: 0.36, blue: 0, alpha: 1)
+        case .red:
+            return isDark
+                ? NSColor(srgbRed: 1, green: 0.35, blue: 0.33, alpha: 1)
+                : NSColor(srgbRed: 0.80, green: 0.11, blue: 0.08, alpha: 1)
+        case nil:
+            return .secondaryLabelColor
+        }
     }
 }
 

--- a/Tests/CodexRunwayTests/StatusBarAppearanceTests.swift
+++ b/Tests/CodexRunwayTests/StatusBarAppearanceTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import Testing
+@testable import CodexRunway
+@testable import CodexRunwayCore
+
+@Suite("Status bar appearance")
+struct StatusBarAppearanceTests {
+    @Test("quota fills contrast against light and dark menu bars")
+    @MainActor
+    func quotaColorsRemainReadable() throws {
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try #require(NSAppearance(named: name))
+            let palette = StatusBarPalette(appearance: appearance)
+            let background = NSColor(white: name == .aqua ? 0.92 : 0.14, alpha: 1)
+            for health in [QuotaHealth.green, .yellow, .red] {
+                let color = try #require(palette.color(for: health).usingColorSpace(.sRGB))
+                #expect(contrast(color, background) >= 3)
+            }
+        }
+    }
+
+    @Test("renders quota meters in both menu bar appearances")
+    @MainActor
+    func renderBothAppearances() throws {
+        _ = NSApplication.shared
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try #require(NSAppearance(named: name))
+            var preferences = RunwayPreferences()
+            preferences.statusBarDisplayStyle = .meters
+            let meters = [20, 51, 90].map { used in
+                QuotaMeter(title: "每周", window: RateWindow(usedPercent: used, windowMinutes: 10_080, resetsAt: nil))
+            }
+            let view = StatusBarContentView(frame: .zero)
+            view.appearance = appearance
+            view.update(StatusBarContentState(
+                configuration: .init(preferences: preferences, language: .simplifiedChinese),
+                content: .init(text: "", meters: meters, displayMinute: 0)))
+            view.frame = NSRect(x: 0, y: 0, width: view.preferredWidth, height: 22)
+            let image = NSImage(size: view.bounds.size)
+            image.lockFocus()
+            appearance.performAsCurrentDrawingAppearance {
+                NSColor(white: name == .aqua ? 0.92 : 0.14, alpha: 1).setFill()
+                view.bounds.fill()
+                view.draw(view.bounds)
+            }
+            image.unlockFocus()
+            let data = try #require(image.tiffRepresentation)
+            let bitmap = try #require(NSBitmapImageRep(data: data))
+            #expect(bitmap.pixelsWide > 100)
+            if let directory = ProcessInfo.processInfo.environment["RUNWAY_TEST_RENDER_DIR"] {
+                let url = URL(fileURLWithPath: directory)
+                try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+                let png = try #require(bitmap.representation(using: .png, properties: [:]))
+                try png.write(to: url.appendingPathComponent(name == .aqua ? "status-light.png" : "status-dark.png"))
+            }
+        }
+    }
+
+    private func contrast(_ foreground: NSColor, _ background: NSColor) -> CGFloat {
+        func luminance(_ color: NSColor) -> CGFloat {
+            let rgb = color.usingColorSpace(.sRGB)!
+            func linear(_ c: CGFloat) -> CGFloat {
+                c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+            }
+            return 0.2126 * linear(rgb.redComponent) + 0.7152 * linear(rgb.greenComponent) + 0.0722 * linear(rgb.blueComponent)
+        }
+        let first = luminance(foreground), second = luminance(background)
+        return (max(first, second) + 0.05) / (min(first, second) + 0.05)
+    }
+}


### PR DESCRIPTION
状态栏进度条在浅色背景下较淡，本次按明暗外观调整进度条和底色，并在外观变化时重新绘制。

验证：单独基于上游 main 编译，并运行状态栏配色与布局测试；覆盖对比度和明暗模式渲染。

此 PR 只修改状态栏显示及对应测试，可独立合并。
